### PR TITLE
Fix sql to work with postgres 12

### DIFF
--- a/openchs-server-api/src/main/resources/db/migration/V1_138__UpdateEncounterNameType.sql
+++ b/openchs-server-api/src/main/resources/db/migration/V1_138__UpdateEncounterNameType.sql
@@ -19,7 +19,7 @@ begin
             from (
                      with recursive recursive_deps(obj_schema, obj_name, obj_type, depth) as
                                         (
-                                            select p_view_schema, p_view_name, null::varchar, 0
+                                            select p_view_schema collate "C", p_view_name collate "C", null::varchar collate "C", 0
                                             union
                                             select dep_schema::varchar,
                                                    dep_name::varchar,


### PR DESCRIPTION
There is one migration that is not expected to work when users start using postgres 12. This needs to be tested on other versions of postgres before we merge into master. 