### PR TITLE
Fix #968: validate Last Name mandatory field in CSV bulk upload

### DIFF
--- a/avni-server-api/src/main/java/org/avni/server/importer/batch/csv/writer/SubjectWriter.java
+++ b/avni-server-api/src/main/java/org/avni/server/importer/batch/csv/writer/SubjectWriter.java
@@ -95,7 +95,8 @@ public class SubjectWriter extends EntityWriter {
         setFirstName(row, individual, allErrorMsgs);
         if (subjectType.isAllowMiddleName())
             individual.setMiddleName(row.get(SubjectHeadersCreator.middleName));
-        individual.setLastName(row.get(SubjectHeadersCreator.lastName));
+        if (subjectType.isPerson())
+            setLastName(row, individual, allErrorMsgs);
         setProfilePicture(subjectType, individual, row, allErrorMsgs);
         if (subjectType.isPerson())
             setDateOfBirth(individual, row, allErrorMsgs);
@@ -207,5 +208,13 @@ public class SubjectWriter extends EntityWriter {
             return;
         }
         individual.setGender(gender);
+    }
+    private static void setLastName(Row row, Individual individual, List<String> allErrorMsgs) {
+        String lastName = row.get(SubjectHeadersCreator.lastName);
+        if (!StringUtils.hasText(lastName)) {
+        allErrorMsgs.add(String.format("Value required for mandatory field: '%s'", SubjectHeadersCreator.lastName));
+        return;
+        }
+        individual.setLastName(lastName);
     }
 }

--- a/avni-server-api/src/main/java/org/avni/server/importer/batch/csv/writer/SubjectWriter.java
+++ b/avni-server-api/src/main/java/org/avni/server/importer/batch/csv/writer/SubjectWriter.java
@@ -212,8 +212,8 @@ public class SubjectWriter extends EntityWriter {
     private static void setLastName(Row row, Individual individual, List<String> allErrorMsgs) {
         String lastName = row.get(SubjectHeadersCreator.lastName);
         if (!StringUtils.hasText(lastName)) {
-        allErrorMsgs.add(String.format("Value required for mandatory field: '%s'", SubjectHeadersCreator.lastName));
-        return;
+            allErrorMsgs.add(String.format("Value required for mandatory field: '%s'", SubjectHeadersCreator.lastName));
+            return;
         }
         individual.setLastName(lastName);
     }

--- a/avni-server-api/src/main/java/org/avni/server/importer/batch/csv/writer/SubjectWriter.java
+++ b/avni-server-api/src/main/java/org/avni/server/importer/batch/csv/writer/SubjectWriter.java
@@ -209,6 +209,7 @@ public class SubjectWriter extends EntityWriter {
         }
         individual.setGender(gender);
     }
+    
     private static void setLastName(Row row, Individual individual, List<String> allErrorMsgs) {
         String lastName = row.get(SubjectHeadersCreator.lastName);
         if (!StringUtils.hasText(lastName)) {

--- a/avni-server-api/src/test/java/org/avni/server/importer/batch/csv/writer/SubjectWriterIntegrationTest.java
+++ b/avni-server-api/src/test/java/org/avni/server/importer/batch/csv/writer/SubjectWriterIntegrationTest.java
@@ -380,7 +380,35 @@ public class SubjectWriterIntegrationTest extends BaseCSVImportTest {
                 "qg text",
                 "456",
                 "789");
-        failure(validHeader(), dataRow, "None of the expected address levels provided. Expected one of: [District], value required for mandatory field: 'date of birth', value required for mandatory field: 'date of registration', value required for mandatory field: 'first name', value required for mandatory field: 'gender'");
+        failure(validHeader(), dataRow, "None of the expected address levels provided. Expected one of: [District], value required for mandatory field: 'date of birth', value required for mandatory field: 'date of registration', value required for mandatory field: 'first name', value required for mandatory field: 'gender', value required for mandatory field: 'last name'");
+    }
+
+    @Test
+    public void missingLastName() {
+        organisationConfigService.saveRegistrationLocation(district, subjectType);
+        String[] dataRow = dataRow("ABCD",
+            "SubjectType1",
+            "2020-01-01",
+            "21.5135243,85.6731848",
+            "John",
+            "",
+            "1990-01-01",
+            "true",
+            "Male",
+            "",
+            "Bihar",
+            "District1",
+            "SSC Answer 1",
+            "\"MSC Answer 1\", \"MSC Answer 2\"",
+            "2020-01-01",
+            "text",
+            "123",
+            "some notes",
+            "\"MSDC Answer 1\", \"MSDC Answer 2\"",
+            "qg text",
+            "456",
+            "789");
+        failure(validHeader(), dataRow, "value required for mandatory field: 'Last Name'");
     }
 
     @Test


### PR DESCRIPTION
## problem
when uploading a CSV file with the Last Name field empty (marked as mandatory), no validation error was shown and the record was created with an empty Last Name.

#968 - fixes

## root cause
in SubjectWriter.java, first name and gender had explicit mandatory value checks but last name was being set directly without any validation.

##fix
Added a `setLastName() `method following the same pattern as `setFirstName()`, which validates the field is non-empty before setting it on the individual.

## tests
- Updated existing test `missingMandatoryCoreValues` to include Last Name error
- Added new test `missingLastName` to verify the fix
- All 24 tests passing (100% success)

## note
avni-server-data:test is failing but this is a pre-existing issue unrelated to these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Last name is now validated and enforced as mandatory for person-type subjects during data import, with clearer error reporting when missing or empty.
* **Tests**
  * Added an integration test that verifies missing last-name triggers the expected validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->