### PR TITLE
Fix #968: Refactor SubjectWriter to improve last name handling on CSV file upload

### DIFF
--- a/avni-server-api/src/main/java/org/avni/server/importer/batch/csv/writer/SubjectWriter.java
+++ b/avni-server-api/src/main/java/org/avni/server/importer/batch/csv/writer/SubjectWriter.java
@@ -95,7 +95,10 @@ public class SubjectWriter extends EntityWriter {
         setFirstName(row, individual, allErrorMsgs);
         if (subjectType.isAllowMiddleName())
             individual.setMiddleName(row.get(SubjectHeadersCreator.middleName));
-        individual.setLastName(row.get(SubjectHeadersCreator.lastName));
+        if (subjectType.isPerson())
+            setLastName(row, individual, allErrorMsgs);
+        else
+            individual.setLastName(row.get(SubjectHeadersCreator.lastName));
         setProfilePicture(subjectType, individual, row, allErrorMsgs);
         if (subjectType.isPerson())
             setDateOfBirth(individual, row, allErrorMsgs);
@@ -207,5 +210,14 @@ public class SubjectWriter extends EntityWriter {
             return;
         }
         individual.setGender(gender);
+    }
+
+    private static void setLastName(Row row, Individual individual, List<String> allErrorMsgs) {
+        String lastName = row.get(SubjectHeadersCreator.lastName);
+        if (!StringUtils.hasText(lastName)) {
+            allErrorMsgs.add(String.format("Value required for mandatory field: '%s'", SubjectHeadersCreator.lastName));
+            return;
+        }
+        individual.setLastName(lastName);
     }
 }

--- a/avni-server-api/src/test/java/org/avni/server/importer/batch/csv/writer/SubjectWriterIntegrationTest.java
+++ b/avni-server-api/src/test/java/org/avni/server/importer/batch/csv/writer/SubjectWriterIntegrationTest.java
@@ -380,7 +380,7 @@ public class SubjectWriterIntegrationTest extends BaseCSVImportTest {
                 "qg text",
                 "456",
                 "789");
-        failure(validHeader(), dataRow, "None of the expected address levels provided. Expected one of: [District], value required for mandatory field: 'date of birth', value required for mandatory field: 'date of registration', value required for mandatory field: 'first name', value required for mandatory field: 'gender'");
+        failure(validHeader(), dataRow, "None of the expected address levels provided. Expected one of: [District], value required for mandatory field: 'date of birth', value required for mandatory field: 'date of registration', value required for mandatory field: 'first name', value required for mandatory field: 'gender', value required for mandatory field: 'last name'");
     }
 
     @Test


### PR DESCRIPTION
## Bug Fix: Last Name Mandatory Field Not Validated During CSV Bulk Upload  #968 

### **Problem:**

- When uploading a CSV file for subject registration, leaving the Last Name field empty does not produce a validation error — even though Last Name is marked as mandatory for Person subject types. The upload succeeds silently and the record is created in the system with an empty Last Name.

- Affected environments: Pre-release, Production Affected org: Testdin (prod) Reproduced by: dinesh@Testdin

- **Steps to Reproduce:**

                  1. Prepare a CSV file for a Person subject type with the Last Name column present but empty for one or more rows
                  
                  2. Upload the CSV via the bulk upload option
                  
                  3. Submit the file

- **Expected:** Upload fails with error — Value required for mandatory field: 'Last Name'


- **Actual:** Upload succeeds, record is created with empty Last Name


### **Root Cause:**

In `SubjectWriter.java`, the Last Name field was set directly without any null/empty check:
                  `// Before fix — no validation
                  individual.setLastName(row.get(SubjectHeadersCreator.lastName));`

By contrast, First Name and Gender both had dedicated validation methods that accumulate an error and abort when the value is blank:
                      `// First Name — correctly validated
                      private static void setFirstName(Row row, Individual individual, List<String> allErrorMsgs) {
                          String firstName = row.get(SubjectHeadersCreator.firstName);
                          if (!StringUtils.hasText(firstName)) {
                              allErrorMsgs.add(String.format("Value required for mandatory field: '%s'", SubjectHeadersCreator.firstName));
                              return;
                          }
                          individual.setFirstName(firstName);
                      }`

Last Name was declared mandatory in `SubjectHeadersCreator` (line 59) but had no corresponding row-level validation in the writer — an inconsistency that caused the silent pass-through.

### **Fix:**

Added a setLastName() method following the exact same pattern as `setFirstName()`, and called it only for Person subject types (the only type where Last Name is a mandatory field):
        
        `// In write() method — replaced direct set with validated method call
        if (subjectType.isPerson())
            setLastName(row, individual, allErrorMsgs);
        else
            individual.setLastName(row.get(SubjectHeadersCreator.lastName));`

  `// New method added at end of class
  private static void setLastName(Row row, Individual individual, List<String> allErrorMsgs) {
      String lastName = row.get(SubjectHeadersCreator.lastName);
      if (!StringUtils.hasText(lastName)) {
          allErrorMsgs.add(String.format("Value required for mandatory field: '%s'", SubjectHeadersCreator.lastName));
          return;
      }
      individual.setLastName(lastName);
  }`

Updated the `missingMandatoryCoreValues` test's expected error message to include the new Last Name error (that test's data row also has an empty Last Name):
        `// Before
        failure(validHeader(), dataRow,
            "...value required for mandatory field: 'first name', value required for mandatory field: 'gender'");`

            `// After
            failure(validHeader(), dataRow,
                "...value required for mandatory field: 'first name', value required for mandatory field: 'gender', value required for mandatory field: 'last name'");`

            `// Before
            failure(validHeader(), dataRow,
                "...value required for mandatory field: 'first name', value required for mandatory field: 'gender'");`

                `// After
                failure(validHeader(), dataRow,
                    "...value required for mandatory field: 'first name', value required for mandatory field: 'gender', value required for mandatory field: 'last name'");`

### **Tests:**

Test class: `SubjectWriterIntegrationTest`
run command:
                        `./gradlew :avni-server-api:test --tests "org.avni.server.importer.batch.csv.writer.SubjectWriterIntegrationTest"`
        
 ### **Note:**

- The fix is scoped to `subjectType.isPerson()` — only Person subject types have Last Name as a mandatory field. For Household and Group subject types, Last Name is not required and continues to be set directly without validation.

- The validation infrastructure (StringUtils.hasText + error accumulation) was already established by `setFirstName()` and `setGender()`. This fix simply applies the same consistent pattern to setLastName().

- A broader issue also exists: form-level mandatory observation fields are never validated during CSV upload (ObservationCreator.getObservations() always passes performMandatoryCheck = false). That is a separate, larger scope issue and is not addressed in this fix.

<!-- This is an auto-generated comment: release notes by `coderabbit.ai` -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced CSV import validation to require and validate last names when importing person records, ensuring incomplete data submissions are rejected with clear error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->