### PR TITLE
#1005: index concept-value lookups via jsonb @> + GIN

### DIFF
--- a/avni-server-api/src/main/resources/db/migration/V1_398__add_observations_gin_index.sql
+++ b/avni-server-api/src/main/resources/db/migration/V1_398__add_observations_gin_index.sql
@@ -1,0 +1,21 @@
+-- #1005: GIN indexes so concept-value lookups (observations @> '{"<uuid>":"<value>"}') use an index
+-- instead of a full-table scan. Serves the external API concept filters
+-- (/api/subjects, /api/encounters, /api/programEncounters) via CHSRepository.withConceptValues.
+-- jsonb_path_ops is smaller/faster than the default jsonb_ops and supports the @> operator we use.
+--
+-- DEPLOYMENT NOTE: Flyway runs migrations inside a transaction, so CREATE INDEX CONCURRENTLY cannot be
+-- used here. On large production tables (e.g. individual ~ 2.5M rows / ~5 GB) a plain CREATE INDEX
+-- takes a write lock for the duration of the build. Pre-create these CONCURRENTLY out-of-band BEFORE
+-- deploying this migration so the IF NOT EXISTS clauses below become no-ops, e.g.:
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_individual_observations_gin
+--       ON individual USING gin (observations jsonb_path_ops);
+--   (repeat for encounter, program_encounter)
+
+CREATE INDEX IF NOT EXISTS idx_individual_observations_gin
+    ON individual USING gin (observations jsonb_path_ops);
+
+CREATE INDEX IF NOT EXISTS idx_encounter_observations_gin
+    ON encounter USING gin (observations jsonb_path_ops);
+
+CREATE INDEX IF NOT EXISTS idx_program_encounter_observations_gin
+    ON program_encounter USING gin (observations jsonb_path_ops);

--- a/avni-server-api/src/test/java/org/avni/server/web/api/SubjectApiControllerIntegrationTest.java
+++ b/avni-server-api/src/test/java/org/avni/server/web/api/SubjectApiControllerIntegrationTest.java
@@ -114,6 +114,35 @@ public class SubjectApiControllerIntegrationTest extends AbstractControllerInteg
     }
 
     @Test
+    public void filtersByConceptValueAcrossDataTypesWithoutRegression() {
+        // #1005: withConceptValues now uses `observations @> {...}` (GIN-indexable) for string-valued
+        // concepts and keeps jsonb_extract_path_text equality for Numeric. Assert both paths match the
+        // same rows as before, and that non-matching values return nothing.
+
+        // Text (string scalar -> indexed @> path)
+        assertEquals(1, filterByConcept(textConcept.getName(), "Hello world"));
+        assertEquals(0, filterByConcept(textConcept.getName(), "Goodbye"));
+
+        // Single coded (stored as answer-concept uuid string -> @> path)
+        assertEquals(1, filterByConcept(singleCodedConcept.getName(), singleCodedConcept.getAnswerConcept("singleCoded1").getUuid()));
+        assertEquals(0, filterByConcept(singleCodedConcept.getName(), singleCodedConcept.getAnswerConcept("singleCoded2").getUuid()));
+
+        // Numeric (stored as JSON number -> falls back to text-equality; must still match)
+        assertEquals(1, filterByConcept(numericConcept.getName(), "10"));
+        assertEquals(0, filterByConcept(numericConcept.getName(), "11"));
+    }
+
+    private int filterByConcept(String conceptName, String value) {
+        return subjectApiController.getSubjects(DateTime.now().minusDays(1),
+                DateTime.now().plusDays(1),
+                subjectType.getName(),
+                String.format("{\"%s\": \"%s\"}", conceptName, value),
+                Collections.singletonList(catchmentData.getAddressLevel1().getUuid()),
+                true,
+                PageRequest.of(0, 10)).getContent().size();
+    }
+
+    @Test
     public void shouldGetDateTimeForDateStyleObservationsForOldVersions() {
         ApiRequestContextHolder.create(new ApiRequestContext("1"));
 

--- a/avni-server-data/src/main/java/org/avni/server/dao/CHSRepository.java
+++ b/avni-server-data/src/main/java/org/avni/server/dao/CHSRepository.java
@@ -3,6 +3,8 @@ package org.avni.server.dao;
 import jakarta.persistence.criteria.*;
 import org.avni.server.domain.CHSEntity;
 import org.avni.server.domain.Concept;
+import org.avni.server.domain.ConceptDataType;
+import org.avni.server.util.ObjectMapperSingleton;
 import org.joda.time.DateTime;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.repository.NoRepositoryBean;
@@ -66,12 +68,35 @@ public interface CHSRepository<T extends CHSEntity> extends AvniCrudRepository<T
         Specification<T> spec = (Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) -> {
             List<Predicate> predicates = new ArrayList<>();
             concepts.forEach((concept, value) -> {
-                predicates.add(cb.equal(jsonExtractPathText(root.get(observationField), concept.getUuid(), cb), value));
+                predicates.add(conceptValuePredicate(root.get(observationField), concept, value, cb));
             });
 
             return cb.and(predicates.toArray(new Predicate[predicates.size()]));
         };
         return spec;
+    }
+
+    /**
+     * Predicate matching a single observation key=value.
+     *
+     * <p>For string-valued concepts (text, coded answer-uuid, id, date-as-text, …) this emits the
+     * jsonb containment operator {@code observations @> {"<uuid>":"<value>"}} via
+     * {@code jsonb_contains_value}, so a {@code GIN(observations jsonb_path_ops)} index can serve the
+     * lookup instead of a full-table scan (#1005). Containment on a {@code {"uuid":"value"}} object is
+     * equivalent to the previous {@code jsonb_extract_path_text(...) = value} for scalar string values,
+     * and (like before) does not match array/object-valued observations such as multi-select coded.
+     *
+     * <p>Numeric concepts are stored as JSON numbers, so the scalar-string containment above would not
+     * match them — those keep the original {@code jsonb_extract_path_text} text-equality (uncommon in this
+     * filter; not index-accelerated). A null value also falls back to the original behaviour.
+     */
+    default Predicate conceptValuePredicate(Path<?> observations, Concept concept, String value, CriteriaBuilder cb) {
+        boolean numeric = ConceptDataType.Numeric.toString().equals(concept.getDataType());
+        if (numeric || value == null) {
+            return cb.equal(jsonExtractPathText(observations, concept.getUuid(), cb), value);
+        }
+        String containment = ObjectMapperSingleton.writeValueAsStringSafe(Map.of(concept.getUuid(), value));
+        return cb.isTrue(cb.function("jsonb_contains_value", Boolean.class, observations, cb.literal(containment)));
     }
 
     default void voidEntity(Long id) {

--- a/avni-server-data/src/main/java/org/avni/server/framework/hibernate/AvniSqlFunctionContributor.java
+++ b/avni-server-data/src/main/java/org/avni/server/framework/hibernate/AvniSqlFunctionContributor.java
@@ -1,0 +1,27 @@
+package org.avni.server.framework.hibernate;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.StandardBasicTypes;
+
+/**
+ * Registers Postgres-specific SQL functions for use from JPA Criteria / HQL.
+ *
+ * <p><b>jsonb_contains_value(jsonb, text)</b> &rarr; renders the Postgres jsonb containment
+ * <b>operator</b> {@code (?1 @> cast(?2 as jsonb))}. It is intentionally emitted as the
+ * {@code @>} operator (not as a function call) so the planner can use a
+ * {@code GIN (observations jsonb_path_ops)} index — a {@code jsonb_contains(a, b)} function
+ * call would NOT be matched to the GIN operator class. Used by
+ * {@code CHSRepository.withConceptValues} for indexed concept-value lookups (see #1005).
+ */
+public class AvniSqlFunctionContributor implements FunctionContributor {
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions.getFunctionRegistry()
+                .patternDescriptorBuilder("jsonb_contains_value", "(?1 @> cast(?2 as jsonb))")
+                .setInvariantType(functionContributions.getTypeConfiguration()
+                        .getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN))
+                .setExactArgumentCount(2)
+                .register();
+    }
+}

--- a/avni-server-data/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/avni-server-data/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+org.avni.server.framework.hibernate.AvniSqlFunctionContributor


### PR DESCRIPTION
Fixes #1005.

## Problem
`CHSRepository.withConceptValues` filtered observations with `jsonb_extract_path_text(observations, '<uuid>') = '<value>'`, which **no index can serve** → a full scan of the subject-type partition + per-row TOAST read. On prod this was 24–73 s per call for the Bahmni integration's `GET /api/subjects?...&concepts={"Sangam Number":...}` lookups (~90–130/day), and the dominant driver of the May app-wide response-time rise (308→413 ms). `EXPLAIN` confirmed ~97% heap I/O.

## Fix
- **`AvniSqlFunctionContributor`** registers `jsonb_contains_value` rendering the Postgres containment **operator** `(?1 @> cast(?2 as jsonb))`. Emitting the `@>` *operator* (not a `jsonb_contains(...)` function call) is required for the planner to use the GIN `jsonb_path_ops` index.
- **`withConceptValues`** now emits `observations @> {"<uuid>":"<value>"}` for string-valued concepts. **Numeric** (stored as a JSON number) keeps the original `jsonb_extract_path_text` text-equality, and a null value also falls back — so it is **non-regressive for every `ConceptDataType`**: string scalars are exactly equivalent; array/object values (multi-select, location, question-group) match nothing under both old and new.
- **`V1_398`** adds GIN `jsonb_path_ops` indexes on `individual`/`encounter`/`program_encounter.observations`.

## Expected gain
Selectivity is ~1 row, so the lookup goes from a full-partition scan (cold 6 s on a 33k-row type; 24–73 s on prod's large type; cache-dependent) to a ~1–5 ms index probe, stable regardless of cache/table size.

## Deployment note
Flyway runs migrations in a transaction, so `CREATE INDEX CONCURRENTLY` can't be used in the migration. On large prod tables (`individual` ≈ 2.5M rows / ~5 GB) **pre-create the indexes `CONCURRENTLY` out-of-band before deploy** so the `IF NOT EXISTS` clauses become no-ops (see the comment in `V1_398`); otherwise the plain `CREATE INDEX` takes a write lock during the build.

## Testing
- New `SubjectApiControllerIntegrationTest.filtersByConceptValueAcrossDataTypesWithoutRegression` covers text / single-coded (`@>` path) / numeric (fallback) / non-match; passes against a real Postgres with `V1_398` applied.
- `:avni-server-data:compileJava` clean; full `make test_server` run in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)