### PR TITLE
#1017 | Suspend transaction around sync-attributes batch launch

### DIFF
--- a/avni-server-api/src/main/java/org/avni/server/service/SubjectTypeService.java
+++ b/avni-server-api/src/main/java/org/avni/server/service/SubjectTypeService.java
@@ -284,6 +284,7 @@ public class SubjectTypeService implements NonScopeAwareService {
         return operationalSubjectTypeRepository.findAllByIsVoidedFalse().stream().map(OperationalSubjectType::getSubjectType);
     }
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void updateSyncAttributesIfRequired(SubjectType subjectType) {
         Boolean isSyncAttribute1Usable = subjectType.isSyncRegistrationConcept1Usable();
         Boolean isSyncAttribute2Usable = subjectType.isSyncRegistrationConcept2Usable();


### PR DESCRIPTION
updateSubjectTypeForWeb became @Transactional in #992 (dc62c703d). Its call to updateSyncAttributesIfRequired launches a Spring Batch job, whose JobRepository rejects creating a JobExecution inside an active transaction ("Existing transaction detected in JobRepository"). Mirror the sibling launchUserSubjectTypeJob and run the launch with
Propagation.NOT_SUPPORTED so the controller transaction is suspended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Internal infrastructure improvement to transaction handling in the subject type service to optimize performance and prevent potential concurrency issues.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->